### PR TITLE
Save block diffs

### DIFF
--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -570,12 +570,12 @@ class AccountDB(BaseAccountDB):
             self._batchdb.commit_to(write_batch, apply_deletes=False)
         self._root_hash_at_last_persist = new_root_hash
 
-    def persist_with_block_diff(self, block_hash: Hash32) -> None:
+    def persist_returning_block_diff(self) -> BlockDiff:
         """
         Persists, including a diff which can be used to unwind/replay the changes this block makes.
         """
 
-        block_diff = BlockDiff(block_hash)
+        block_diff = BlockDiff()
 
         # 1. Grab all the changed accounts and their previous values
 
@@ -625,8 +625,8 @@ class AccountDB(BaseAccountDB):
             new_account_value = self._get_encoded_account(address, from_journal=False)
             block_diff.set_account_changed(address, old_account_value, new_account_value)
 
-        # 5. persist the block diff
-        block_diff.write_to(self._raw_store_db)
+        # 5. return the block diff
+        return block_diff
 
     def _changed_accounts(self) -> DBDiff:
         """

--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -609,11 +609,7 @@ class AccountDB(BaseAccountDB):
             for key, new_value in diff.pending_items():
                 slot = big_endian_to_int(key)
                 old_value = store.get(slot, from_journal=False)
-                # TODO: this seems incredibly wrong
-                if old_value == 0:
-                    old_value_bytes = b''
-                else:
-                    old_value_bytes = int_to_big_endian(old_value)
+                old_value_bytes = int_to_big_endian(old_value)
                 block_diff.set_storage_changed(address, slot, old_value_bytes, new_value)
 
         old_account_values: Dict[Address, bytes] = dict()

--- a/eth/db/block_diff.py
+++ b/eth/db/block_diff.py
@@ -1,0 +1,110 @@
+from collections import defaultdict
+from typing import (
+    cast,
+    Dict,
+    Iterable,
+    NamedTuple,
+    Optional,
+    Tuple,
+)
+
+from eth_typing import (
+    Address,
+    Hash32,
+)
+import rlp
+
+from eth.db.backends.base import BaseDB
+from eth.db.schema import SchemaTurbo
+from eth.rlp.accounts import Account
+
+
+class Change(NamedTuple):
+    old: object
+    new: object
+
+
+class BlockDiff:
+    """
+    TODO: I'm not sure where this class belongs
+    """
+
+    def __init__(self, block_hash: Hash32) -> None:
+        self.block_hash = block_hash
+
+        self.changed_accounts: Dict[Address, Change] = dict()
+        self.changed_storage_items: Dict[Address, Dict[int, Change]] = defaultdict(dict)
+
+    def set_account_changed(self, address: Address, old: bytes, new: bytes) -> None:
+        self.changed_accounts[address] = Change(old, new)
+
+    def set_storage_changed(self, address: Address, slot: int, old: bytes, new: bytes) -> None:
+        self.changed_storage_items[address][slot] = Change(old, new)
+
+    def get_changed_accounts(self) -> Iterable[Address]:
+        return tuple(
+            set(self.changed_accounts.keys()) | set(self.changed_storage_items.keys())
+        )
+
+    def get_changed_storage_items(self) -> Iterable[Tuple[Address, int, int, int]]:
+        def storage_items_to_diff(item: Dict[int, Change]) -> Iterable[Tuple[int, int, int]]:
+            return [
+                (key, cast(int, change.old), cast(int, change.new))
+                for key, change in item.items()
+            ]
+
+        return [
+            (acct, key, old_value, new_value)
+            for acct, value in self.changed_storage_items.items()
+            for key, old_value, new_value in storage_items_to_diff(value)
+        ]
+
+    def get_account(self, address: Address, new: bool = True) -> bytes:
+        change = self.changed_accounts[address]
+        return cast(bytes, change.new) if new else cast(bytes, change.old)
+
+    def get_decoded_account(self, address: Address, new: bool = True) -> Optional[Account]:
+        encoded = self.get_account(address, new)
+        if encoded == b'':
+            return None  # this means the account used to or currently does not exist
+        return rlp.decode(encoded, sedes=Account)
+
+    @classmethod
+    def from_db(cls, db: BaseDB, block_hash: Hash32) -> 'BlockDiff':
+        """
+        KeyError is thrown if a diff was not saved for the provided {block_hash}
+        """
+
+        encoded_diff = db[SchemaTurbo.make_block_diff_lookup_key(block_hash)]
+        diff = rlp.decode(encoded_diff)
+
+        accounts, storage_items = diff
+
+        block_diff = cls(block_hash)
+
+        for key, old, new in accounts:
+            block_diff.set_account_changed(key, old, new)
+
+        for key, slot, old, new in storage_items:
+            block_diff.set_storage_changed(key, slot, old, new)
+
+        return block_diff
+
+    def write_to(self, db: BaseDB) -> None:
+
+        # TODO: this should probably verify that the state roots have all been added
+
+        accounts = [
+            [key, value.old, value.new]
+            for key, value in self.changed_accounts.items()
+        ]
+
+        storage_items = self.get_changed_storage_items()
+
+        diff = [
+            accounts,
+            storage_items
+        ]
+
+        encoded_diff = rlp.encode(diff)
+        db[SchemaTurbo.make_block_diff_lookup_key(self.block_hash)] = encoded_diff

--- a/eth/db/block_diff.py
+++ b/eth/db/block_diff.py
@@ -33,9 +33,7 @@ TODO: Decide on the best interface for returning changes:
 
 class BlockDiff:
 
-    def __init__(self, block_hash: Hash32) -> None:
-        self.block_hash = block_hash
-
+    def __init__(self) -> None:
         self.old_account_values: Dict[Address, Optional[bytes]] = dict()
         self.new_account_values: Dict[Address, Optional[bytes]] = dict()
 
@@ -104,7 +102,7 @@ class BlockDiff:
 
         accounts, storage_items = diff
 
-        block_diff = cls(block_hash)
+        block_diff = cls()
 
         for key, old, new in accounts:
             block_diff.set_account_changed(key, old, new)
@@ -115,7 +113,7 @@ class BlockDiff:
 
         return block_diff
 
-    def write_to(self, db: BaseDB) -> None:
+    def write_to(self, db: BaseDB, block_hash: Hash32) -> None:
 
         # TODO: this should probably verify that the state roots have all been added
 
@@ -132,4 +130,4 @@ class BlockDiff:
         ]
 
         encoded_diff = rlp.encode(diff)
-        db[SchemaTurbo.make_block_diff_lookup_key(self.block_hash)] = encoded_diff
+        db[SchemaTurbo.make_block_diff_lookup_key(block_hash)] = encoded_diff

--- a/eth/db/block_diff.py
+++ b/eth/db/block_diff.py
@@ -22,10 +22,16 @@ from eth.db.schema import SchemaTurbo
 from eth.rlp.accounts import Account
 
 
+"""
+TODO: Decide on the best interface for returning changes:
+- diff.get_slot_change() -> [old, new]
+- diff.get_slot_change(new=FAlse) -> old
+- diff.get_slot_change(kind=BlockDiff.OLD) -> old
+- diff.get_old_slot_value() & diff.get_new_slot_value()
+"""
+
+
 class BlockDiff:
-    """
-    TODO: I'm not sure where this class belongs
-    """
 
     def __init__(self, block_hash: Hash32) -> None:
         self.block_hash = block_hash

--- a/eth/db/schema.py
+++ b/eth/db/schema.py
@@ -62,6 +62,11 @@ class SchemaV1(BaseSchema):
 
 class SchemaTurbo(SchemaV1):
     current_schema_lookup_key: bytes = b'current-schema'
+    _block_diff_prefix = b'block-diff'
+
+    @classmethod
+    def make_block_diff_lookup_key(cls, block_hash: Hash32) -> bytes:
+        return cls._block_diff_prefix + b':' + block_hash
 
 
 def get_schema(db: BaseDB) -> Schemas:

--- a/eth/db/storage.py
+++ b/eth/db/storage.py
@@ -31,6 +31,9 @@ from eth.db.batch import (
 from eth.db.cache import (
     CacheDB,
 )
+from eth.db.diff import (
+    DBDiff
+)
 from eth.db.journal import (
     JournalDB,
 )
@@ -271,3 +274,12 @@ class AccountStorageDB:
         self._validate_flushed()
         if self._storage_lookup.has_changed_root:
             self._storage_lookup.commit_to(db)
+
+    def diff(self) -> DBDiff:
+        """
+        Returns all the changes that would be saved if persist() were called.
+
+        Note: Calling make_storage_root() wipes away changes, after it is called this method will
+        return an empty diff.
+        """
+        return self._journal_storage.diff()

--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -679,9 +679,13 @@ class VM(BaseVM):
 
         # TODO: only do this if we're in turbo mode
         # TODO: will we always know the hash here?
-        self.state.persist_with_block_diff(block.hash)
+        block_diff = self.state.persist_returning_block_diff()
 
-        return block.copy(header=block.header.copy(state_root=self.state.state_root))
+        result = block.copy(header=block.header.copy(state_root=self.state.state_root))
+
+        basedb = self.chaindb.db
+        block_diff.write_to(basedb, result.hash)
+        return result
 
     def pack_block(self, block: BaseBlock, *args: Any, **kwargs: Any) -> BaseBlock:
         """

--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -675,7 +675,11 @@ class VM(BaseVM):
 
         # We need to call `persist` here since the state db batches
         # all writes until we tell it to write to the underlying db
-        self.state.persist()
+        # self.state.persist()
+
+        # TODO: only do this if we're in turbo mode
+        # TODO: will we always know the hash here?
+        self.state.persist_with_block_diff(block.hash)
 
         return block.copy(header=block.header.copy(state_root=self.state.state_root))
 

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -253,6 +253,12 @@ class BaseState(Configurable, ABC):
     def persist(self) -> None:
         self._account_db.persist()
 
+    def persist_with_block_diff(self, block_hash: Hash32) -> None:
+        """
+        Persists all changes and also saves a record of them to the database.
+        """
+        self._account_db.persist_with_block_diff(block_hash)
+
     #
     # Access self.prev_hashes (Read-only)
     #

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -26,6 +26,7 @@ from eth.constants import (
 from eth.db.account import (
     BaseAccountDB,
 )
+from eth.db.block_diff import BlockDiff
 from eth.db.backends.base import (
     BaseAtomicDB,
 )
@@ -253,11 +254,11 @@ class BaseState(Configurable, ABC):
     def persist(self) -> None:
         self._account_db.persist()
 
-    def persist_with_block_diff(self, block_hash: Hash32) -> None:
+    def persist_returning_block_diff(self) -> BlockDiff:
         """
         Persists all changes and also saves a record of them to the database.
         """
-        self._account_db.persist_with_block_diff(block_hash)
+        return self._account_db.persist_returning_block_diff()
 
     #
     # Access self.prev_hashes (Read-only)

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ deps = {
         "pytest-cov==2.5.1",
         "pytest-watch>=4.1.0,<5",
         "pytest-xdist==1.18.1",
+        "vyper==0.1.0b11",
     ],
     'lint': [
         "flake8==3.5.0",

--- a/tests/core/chain-object/test_turbo_chain.py
+++ b/tests/core/chain-object/test_turbo_chain.py
@@ -50,7 +50,6 @@ def chain(chain_without_block_validation):
     return chain_without_block_validation
 
 
-# TODO: why are many different tests run here?
 def test_import_block_saves_block_diff(chain, funded_address, funded_address_private_key):
     tx = new_transaction(
         chain.get_vm(),
@@ -74,9 +73,11 @@ def test_import_block_saves_block_diff(chain, funded_address, funded_address_pri
     # the actual test, did we write out all the changes which happened?
     base_db = chain.chaindb.db
     diff = BlockDiff.from_db(base_db, imported_block_hash)
-    assert diff.get_changed_accounts() == {
-        funded_address, CONTRACT_ADDRESS, imported_header.coinbase
-    }
+    assert len(diff.get_changed_accounts()) == 3
+    assert CONTRACT_ADDRESS in diff.get_changed_accounts()
+    assert imported_header.coinbase in diff.get_changed_accounts()
+    assert funded_address in diff.get_changed_accounts()
+
     assert diff.get_changed_slots(CONTRACT_ADDRESS) == {0}
     assert diff.get_slot_change(CONTRACT_ADDRESS, 0) == (0, 42)
 

--- a/tests/core/chain-object/test_turbo_chain.py
+++ b/tests/core/chain-object/test_turbo_chain.py
@@ -1,0 +1,99 @@
+"""
+some tests that chain correctly manipulates the turbo database
+"""
+import pytest
+
+from eth_utils.toolz import (
+    assoc,
+)
+
+from eth.db.block_diff import BlockDiff
+from eth.tools._utils.vyper import (
+    compile_vyper_lll,
+)
+
+from tests.core.helpers import (
+    new_transaction,
+)
+
+
+CONTRACT_ADDRESS = b'\x10' * 20
+
+
+@pytest.fixture
+def genesis_state(base_genesis_state):
+    """
+    A little bit of magic, this overrides the genesis_state fixture which was defined elsewhere so
+    chain_without_block_validation uses the genesis state specified here.
+    """
+
+    # 1. when called this contract makes a simple change to the state
+    code = ['SSTORE', 0, 42]
+    bytecode = compile_vyper_lll(code)[0]
+
+    # 2. put that code somewhere useful
+    return assoc(
+        base_genesis_state,
+        CONTRACT_ADDRESS,
+        {
+            'balance': 0,
+            'nonce': 0,
+            'code': bytecode,
+            'storage': {},
+        }
+    )
+
+
+@pytest.fixture
+def chain(chain_without_block_validation):
+    # make things a little less verbose
+    return chain_without_block_validation
+
+
+# TODO: why are many different tests run here?
+def test_import_block_saves_block_diff(chain, funded_address, funded_address_private_key):
+    tx = new_transaction(
+        chain.get_vm(),
+        funded_address,
+        CONTRACT_ADDRESS,
+        data=b'',
+        private_key=funded_address_private_key,
+    )
+
+    new_block, _, _ = chain.build_block_with_transactions([tx])
+    imported_block, _, _ = chain.import_block(new_block)
+
+    imported_header = imported_block.header
+    imported_block_hash = imported_header.hash
+
+    # sanity check, did the transaction go through?
+    assert len(imported_block.transactions) == 1
+    state = chain.get_vm(imported_header).state
+    assert state.get_storage(CONTRACT_ADDRESS, 0) == 42
+
+    # the actual test, did we write out all the changes which happened?
+    base_db = chain.chaindb.db
+    diff = BlockDiff.from_db(base_db, imported_block_hash)
+    assert diff.get_changed_accounts() == {
+        funded_address, CONTRACT_ADDRESS, imported_header.coinbase
+    }
+    assert diff.get_changed_slots(CONTRACT_ADDRESS) == {0}
+    assert diff.get_slot_change(CONTRACT_ADDRESS, 0) == (0, 42)
+
+    assert diff.get_changed_slots(funded_address) == set()
+    assert diff.get_changed_slots(imported_header.coinbase) == set()
+
+    # do some spot checks to make sure different fields were saved
+
+    assert diff.get_decoded_account(imported_header.coinbase, new=False) is None
+    new_coinbase_balance = diff.get_decoded_account(imported_header.coinbase, new=True).balance
+    assert new_coinbase_balance > 0
+
+    old_sender_balance = diff.get_decoded_account(funded_address, new=False).balance
+    new_sender_balance = diff.get_decoded_account(funded_address, new=True).balance
+    assert old_sender_balance > new_sender_balance
+
+    old_contract_nonce = diff.get_decoded_account(CONTRACT_ADDRESS, new=False).nonce
+    new_contract_nonce = diff.get_decoded_account(CONTRACT_ADDRESS, new=True).nonce
+    assert old_contract_nonce == 0
+    assert new_contract_nonce == 0

--- a/tests/core/vm/test_block_diffs.py
+++ b/tests/core/vm/test_block_diffs.py
@@ -1,0 +1,118 @@
+import pytest
+
+from eth_utils import int_to_big_endian
+
+from eth_hash.auto import keccak
+
+from eth.constants import BLANK_ROOT_HASH
+from eth.db.atomic import AtomicDB
+from eth.db.block_diff import BlockDiff
+from eth.db.account import AccountDB
+from eth.db.storage import StorageLookup
+
+ACCOUNT = b'\xaa' * 20
+BLOCK_HASH = keccak(b'one')
+
+"""
+TODO: Some tests remain to be written:
+- Are we sure that old accounts are being recorded? Start from an account which already has a value
+  and check that it is saved.
+- Check that deleting an account is correctly saved.
+- Test that this behavior is trigger during block import (if Turbo-mode is enabled)
+- Test for more fields, such as account balances.
+- Test that this works even under calls to things like commit() and snapshot()
+- Test that these diffs can be applied to something and the correct resulting state obtained
+"""
+
+
+@pytest.fixture
+def base_db():
+    return AtomicDB()
+
+
+@pytest.fixture
+def account_db(base_db):
+    return AccountDB(base_db)
+
+
+# Some basic tests that BlockDiff works as expected and can round-trip data to the database
+
+
+def test_no_such_diff_raises_key_error(base_db):
+    with pytest.raises(KeyError):
+        BlockDiff.from_db(base_db, BLOCK_HASH)
+
+
+def test_can_persist_empty_block_diff(base_db):
+    orig = BlockDiff(BLOCK_HASH)
+    orig.write_to(base_db)
+
+    block_diff = BlockDiff.from_db(base_db, BLOCK_HASH)
+    assert len(block_diff.get_changed_accounts()) == 0
+
+
+def test_can_persist_changed_account(base_db):
+    orig = BlockDiff(BLOCK_HASH)
+    orig.set_account_changed(ACCOUNT, b'old', b'new')  # TODO: more realistic data
+    orig.write_to(base_db)
+
+    block_diff = BlockDiff.from_db(base_db, BLOCK_HASH)
+    assert block_diff.get_changed_accounts() == (ACCOUNT,)
+    assert block_diff.get_account(ACCOUNT, new=True) == b'new'
+    assert block_diff.get_account(ACCOUNT, new=False) == b'old'
+
+
+# Some tests that AccountDB saves a block diff when persist()ing
+
+
+def test_account_diffs(account_db):
+    account_db.set_nonce(ACCOUNT, 10)
+    account_db.persist_with_block_diff(BLOCK_HASH)
+
+    diff = BlockDiff.from_db(account_db._raw_store_db, BLOCK_HASH)
+    assert diff.get_changed_accounts() == (ACCOUNT, )
+    new_account = diff.get_decoded_account(ACCOUNT, new=True)
+    assert new_account.nonce == 10
+
+    assert diff.get_decoded_account(ACCOUNT, new=False) is None
+
+
+def test_persists_storage_changes(account_db):
+    account_db.set_storage(ACCOUNT, 1, 10)
+    account_db.persist_with_block_diff(BLOCK_HASH)
+
+    diff = BlockDiff.from_db(account_db._raw_store_db, BLOCK_HASH)
+    assert diff.get_changed_accounts() == (ACCOUNT, )
+
+    key = int_to_big_endian(1)
+
+    # TODO: provide some interface, this shouldn't be reading items directly out of the diff
+    assert ACCOUNT in diff.changed_storage_items
+    assert tuple(diff.changed_storage_items[ACCOUNT].keys()) == (key,)
+    assert diff.changed_storage_items[ACCOUNT][key].old == b''
+    assert diff.changed_storage_items[ACCOUNT][key].new == bytes([10])
+
+
+def test_persists_state_root(account_db):
+    """
+    When the storage items change the account's storage root also changes and that change also
+    needs to be persisted.
+    """
+
+    # First, compute the expected new storage root
+    db = AtomicDB()
+    example_lookup = StorageLookup(db, BLANK_ROOT_HASH, ACCOUNT)
+    key = int_to_big_endian(1)
+    example_lookup[key] = int_to_big_endian(10)
+    expected_root = example_lookup.get_changed_root()
+
+    # Next, make the same change to out storage
+    account_db.set_storage(ACCOUNT, 1, 10)
+    account_db.persist_with_block_diff(BLOCK_HASH)
+
+    # The new state root should have been included as part of the diff.
+
+    diff = BlockDiff.from_db(account_db._raw_store_db, BLOCK_HASH)
+    assert diff.get_changed_accounts() == (ACCOUNT, )
+    new_account = diff.get_decoded_account(ACCOUNT, new=True)
+    assert new_account.storage_root == expected_root


### PR DESCRIPTION
When blocks are imported a record of their changes is added to the database.

Remaining work:
- Test that this happens when a block is imported
- Only save diffs if the database is a turbo database and we're running in turbo mode
- Using sedes might make the Block diffs code a little shorter / less error prone?

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()